### PR TITLE
Correct data_thumbnail location

### DIFF
--- a/hats-ivoa.tex
+++ b/hats-ivoa.tex
@@ -129,10 +129,10 @@ catalog/
 |-- [REQUIRED] properties
 |-- [RECOMMENDED] partition_info.csv
 |-- [OPTIONAL] point_map.fits
-|-- [OPTIONAL] data_thumbnail.parquet
 +-- dataset/
     |-- [RECOMMENDED] _metadata
     |-- [RECOMMENDED] _common_metadata
+    |-- [OPTIONAL] data_thumbnail.parquet
     |-- Norder=0/
     |-- Norder=1/
     |-- Norder=2/


### PR DESCRIPTION
Changes location of data_thumbnail to be inside dataset/ (consistent with location used for Rubin dataset and others). Closes https://github.com/astronomy-commons/hats/issues/614. 