### PR TITLE
Fix `hats_estsize` units

### DIFF
--- a/hats-ivoa.tex
+++ b/hats-ivoa.tex
@@ -447,7 +447,7 @@ hats\_coordinate\_epoch &For the default ra and dec (hats\_col\_ra, hats\_col\_d
 hats\_copyright &Copyright mention associated to the dataset or HATS - Format: free text \\
 hats\_creation\_date &HATS first creation date - Format: ISO 8601 => YYYY-mm-ddTHH:MMZ \\
 hats\_creator &Institute or person who built the HATS. Format: free text. Ex : CDS (T. Boch) \\
-hats\_estsize &HATS size estimation. Format: positive integer. Unit : KB \\
+hats\_estsize &HATS size estimation. Format: positive integer. Unit : KiB \\
 hats\_frame &Coordinate frame reference. Format: word "equatorial" (ICRS), "galactic", "ecliptic" \\
 hats\_index\_column &For index tables, the column that is indexed over \\
 hats\_index\_extra\_column &For index tables, extra columns that are carried through with the index \\


### PR DESCRIPTION
The hats size estimate is calculated in binary ([hats.catalog.TableProperties#L370](https://github.com/astronomy-commons/hats/blob/e1c6d8afe0e2e29bb97d3d3fa2bceee643b57490/src/hats/catalog/dataset/table_properties.py#L370)).